### PR TITLE
Remove shared subscriptions prefix when matching topics

### DIFF
--- a/spec/v3_subscription_spec.cr
+++ b/spec/v3_subscription_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+
+module MQTT::V3
+  describe MQTT::V3 do
+    it "should match basic topics" do
+      MQTT::V3::Client.topic_matches("my/favorite/topic", "my/favorite/topic").should be_true
+      MQTT::V3::Client.topic_matches("my/favorite/topic", "my/favorite").should be_false
+      MQTT::V3::Client.topic_matches("my/favorite/topic", "my/favorite/topic/etc").should be_false
+    end
+
+    it "should match topics with multi-level wildcards" do
+      MQTT::V3::Client.topic_matches("my/favorite/topic/#", "my/favorite/topic/a").should be_true
+      MQTT::V3::Client.topic_matches("my/favorite/topic/#", "my/favorite/topic/a/b").should be_true
+    end
+
+    it "should match topics with single-level wildcards" do
+      MQTT::V3::Client.topic_matches("my/favorite/topic/+/here", "my/favorite/topic/is/here").should be_true
+      MQTT::V3::Client.topic_matches("my/favorite/topic/+/here", "my/favorite/topic/is/not").should be_false
+      MQTT::V3::Client.topic_matches("my/favorite/topic/+/here", "my/favorite/topic/here").should be_false
+    end
+
+    it "should match shared subscriptions" do
+      MQTT::V3::Client.topic_matches("$share/groupid/my/favorite/topic/+/here", "my/favorite/topic/is/here").should be_true
+    end
+  end # describe MQTT::V3
+end   # MQTT::V3

--- a/src/mqtt/v3/client.cr
+++ b/src/mqtt/v3/client.cr
@@ -425,7 +425,8 @@ module MQTT
 
       # Based on https://github.com/ralphtheninja/mqtt-match/blob/master/index.js
       def topic_matches(filter : String, topic : String)
-        filter_array = filter.split("/")
+        #remove any MQTT shared subscription prefix
+        filter_array = filter.sub(/^\$[^\/]+\/[^\/]+\//, "").split("/")
         topic_array = topic.split("/")
         length = filter_array.size
 

--- a/src/mqtt/v3/client.cr
+++ b/src/mqtt/v3/client.cr
@@ -14,7 +14,9 @@ module MQTT
       # Based on https://github.com/ralphtheninja/mqtt-match/blob/master/index.js
       def self.topic_matches(filter : String, topic : String)
         filter_array = filter.split("/")
-        filter_array = filter_array[2..-1] if filter_array.first.starts_with?("$")  #remove any MQTT shared subscription prefix
+        # remove any MQTT shared subscription prefix
+        # https://emqx.medium.com/introduction-to-mqtt-5-0-protocol-shared-subscription-4c23e7e0e3c1
+        filter_array = filter_array[2..-1] if filter_array.first? == "$share"
         topic_array = topic.split("/")
         length = filter_array.size
 

--- a/src/mqtt/v3/client.cr
+++ b/src/mqtt/v3/client.cr
@@ -432,7 +432,7 @@ module MQTT
         end
 
         @subscription_cbs.each do |filter, callbacks|
-          if topic_matches(filter, topic)
+          if MQTT::V3::Client.topic_matches(filter, topic)
             callbacks.each do |callback|
               begin
                 callback.call(topic, payload)


### PR DESCRIPTION
My MQTT broker (VerneMQ) allows shared subscriptions even when running v3... though I believe technically they're a v5 feature (https://www.hivemq.com/blog/mqtt5-essentials-part7-shared-subscriptions/).

I'm honestly not thrilled about this particular implementation - it was the easy route but requires a regex on each receive.  A better solution would probably be to re-architect subscriptions and separate the topic from the filter (since those can be different in the case of shared subscriptions).

So mostly just throwing this out there to see what you think.